### PR TITLE
카카오 로그인 및 회원가입 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,14 +5,14 @@ import Router from './Router';
 import { useUser } from '@hooks/useUser';
 
 function App() {
-  const { data: user, isLoading, isError, error } = useUser();
+  // const { data: user, isLoading, isError, error } = useUser();
 
-  if (isError) {
-    console.error(error);
-    tokenStorage.clearTokens();
-  }
+  // if (isError) {
+  //   console.error(error);
+  //   tokenStorage.clearTokens();
+  // }
 
-  if (isLoading) return null;
+  // if (isLoading) return null;
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/Pages/MyPage/EditProfile/EditProfile.tsx
+++ b/src/Pages/MyPage/EditProfile/EditProfile.tsx
@@ -11,7 +11,7 @@ import Spinner from '@components/Auth/Spinner';
 
 function EditProfile() {
   const navigate = useNavigate();
-  const { data: user } = useUser();
+  // const { data: user } = useUser();
   // todo: 타입 추가 정의
   const [userInfo, setUserInfo] = useState({});
   const { isOpen, open, close } = useModal();
@@ -50,10 +50,10 @@ function EditProfile() {
     <>
       <ProfileSetupForm
         isEdit={true}
-        defaultProfileImgSrc={user.profile_image || defaultProfileImg}
-        defaultNickname={user.nickname}
-        defaultAddress={user.town}
-        defaultCoordinates={user.coordinates}
+        defaultProfileImgSrc={'' || defaultProfileImg}
+        defaultNickname={'임시'}
+        defaultAddress={'임시'}
+        defaultCoordinates={null}
         handleSubmit={handleSubmit}
       />
       <ConfirmModal

--- a/src/Pages/MyPage/MyPage.tsx
+++ b/src/Pages/MyPage/MyPage.tsx
@@ -10,6 +10,8 @@ import DividedLine from '@components/common/DividedLine';
 import MannersContainer from '@components/MyPage/Manners/MannersContainer';
 import ConfirmModal from '@components/common/ConfirmModal';
 import { tokenStorage } from '@utils/tokenStorage';
+import { useDispatch } from 'react-redux';
+import { logOut } from '@store/slices/authSlice';
 
 const MyPageContainer = styled.div`
   width: 100%;
@@ -27,6 +29,7 @@ const TopSection = styled.div`
 function MyPage() {
   const navigate = useNavigate();
   const { isOpen, open, close } = useModal();
+  const dispatch = useDispatch();
 
   const {
     isOpen: isLogoutModalOpen,
@@ -42,7 +45,7 @@ function MyPage() {
   };
 
   const handleConfirm = () => {
-    tokenStorage.clearTokens();
+    dispatch(logOut());
     navigate('/?action=logout');
   };
 

--- a/src/Pages/SingUp/SignUp.tsx
+++ b/src/Pages/SingUp/SignUp.tsx
@@ -47,7 +47,7 @@ function SignUp() {
   const handleSubmit = async (
     nickname: string,
     coordinates: Coordinates,
-    town: string,
+    address: string,
     profileImgFile: File | null
   ) => {
     const signUpData = {
@@ -57,7 +57,7 @@ function SignUp() {
       profileImage,
       // imageFile: profileImgFile,
       addressRequest: {
-        name: town,
+        name: address,
         longitude: coordinates.latitude,
         latitude: coordinates.longitude,
         type: 'main',

--- a/src/Pages/SingUp/SignUp.tsx
+++ b/src/Pages/SingUp/SignUp.tsx
@@ -15,7 +15,7 @@ function SignUp() {
   const navigate = useNavigate();
   const location = useLocation();
   const state = location.state as NewUserResponse;
-  const { authId, authType, nickname, profileImage } = state;
+  const { authId, authType, nickname, profileImage } = state.data;
   const [userInfo, setUserInfo] = useState<RegisterRequest>({
     authId,
     authType,
@@ -64,7 +64,7 @@ function SignUp() {
     setUserInfo((prev) => ({
       ...prev,
       nickname,
-      imageFile: profileImgFile,
+      // imageFile: profileImgFile,
       latitude: coordinates.latitude,
       longitude: coordinates.longitude,
     }));

--- a/src/components/Auth/OAuthRedirectHandler.tsx
+++ b/src/components/Auth/OAuthRedirectHandler.tsx
@@ -4,6 +4,8 @@ import { NewUserResponse, OAuthServiceType } from '@/types/AuthTypes';
 import Spinner from './Spinner';
 import useQueryString from '@hooks/useQueryString';
 import { useLoginMutation } from '@store/api/authApiSlice';
+import { useDispatch } from 'react-redux';
+import { login as loggedIn } from '@store/slices/authSlice';
 
 interface IOAuthRedirectHandlerProps {
   serviceName: OAuthServiceType;
@@ -13,6 +15,7 @@ function OAuthRedirectHandler({ serviceName }: IOAuthRedirectHandlerProps) {
   const code = useQueryString('code') as string; // 인가 코드
   const navigate = useNavigate();
   const [login] = useLoginMutation();
+  const dispatch = useDispatch();
 
   const handleSuccessfulLogin = async () => {
     navigate('/', { replace: true });
@@ -31,15 +34,11 @@ function OAuthRedirectHandler({ serviceName }: IOAuthRedirectHandlerProps) {
     const handleOAuthLogin = async () => {
       try {
         const result = await login({ serviceName, code }).unwrap();
-
-        if (result.code !== 200) {
-          throw new Error('알 수 없는 응답 코드' + result.code);
-        }
-
         if (result.message.includes('신규 회원')) {
           handleNewUser(result as NewUserResponse);
         } else {
           await handleSuccessfulLogin();
+          dispatch(loggedIn());
         }
       } catch (error) {
         handleError(error);

--- a/src/components/Auth/OAuthRedirectHandler.tsx
+++ b/src/components/Auth/OAuthRedirectHandler.tsx
@@ -23,7 +23,6 @@ function OAuthRedirectHandler({ serviceName }: IOAuthRedirectHandlerProps) {
   };
 
   const handleError = (error: any) => {
-    console.error(error);
     alert('로그인에 실패했습니다. error: ' + error);
     navigate('/auth', { replace: true });
   };
@@ -32,12 +31,14 @@ function OAuthRedirectHandler({ serviceName }: IOAuthRedirectHandlerProps) {
     const handleOAuthLogin = async () => {
       try {
         const result = await login({ serviceName, code }).unwrap();
-        if (result.code === 200) {
-          await handleSuccessfulLogin();
-        } else if (result.code === 301) {
+        if (result.code !== 200) {
+          throw new Error('알 수 없는 응답 코드' + result.code);
+        }
+
+        if (result.message.includes('신규 회원')) {
           handleNewUser(result as NewUserResponse);
         } else {
-          throw new Error('알 수 없는 응답 코드' + result.code);
+          await handleSuccessfulLogin();
         }
       } catch (error) {
         handleError(error);

--- a/src/components/Auth/OAuthRedirectHandler.tsx
+++ b/src/components/Auth/OAuthRedirectHandler.tsx
@@ -31,6 +31,7 @@ function OAuthRedirectHandler({ serviceName }: IOAuthRedirectHandlerProps) {
     const handleOAuthLogin = async () => {
       try {
         const result = await login({ serviceName, code }).unwrap();
+
         if (result.code !== 200) {
           throw new Error('알 수 없는 응답 코드' + result.code);
         }

--- a/src/components/MyPage/Profile.tsx
+++ b/src/components/MyPage/Profile.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import RatingBadge from '@components/common/RatingBadge';
 import { useUser } from '@hooks/useUser';
+import defaultCharacterImg from '@Assets/Character_Icons/Character_circle.svg';
 
 const ProfileContainer = styled.div`
   width: 100%;
@@ -58,17 +59,17 @@ const TextSection = styled.div`
 
 function Profile() {
   const navigate = useNavigate();
-  const { data: user } = useUser();
+  // const { data: user } = useUser();
   const handleEditBtnClick = () => navigate('edit');
 
   return (
     <ProfileContainer>
       <div className="left">
-        <img className="profile-img" src={user.profile_image} />
+        <img className="profile-img" src={'' || defaultCharacterImg} />
         <TextSection>
-          <div className="nickname">{user.nickname}</div>
+          <div className="nickname">임시 닉네임</div>
           <div className="grade">
-            내 거래 등급 <RatingBadge rating={user.grade} />
+            내 거래 등급 <RatingBadge rating="one" />
           </div>
         </TextSection>
       </div>

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -6,22 +6,21 @@ import CommonModal from './common/CommonModal';
 
 // 로그인 한 유저만 접근 가능한 페이지를 위한 컴포넌트
 function PrivateRoute() {
-  const { data: user } = useUser();
-  const isLogin = Boolean(user);
+  const isLoggedIn = useUser();
   const navigate = useNavigate();
   const { isOpen, open, close } = useModal();
   useEffect(() => {
-    if (!isLogin) {
+    if (!isLoggedIn) {
       open();
     }
-  }, [isLogin]);
+  }, [isLoggedIn]);
 
   const handleOkClick = () => {
     close();
     navigate('/auth', { replace: true });
   };
 
-  if (!isLogin) {
+  if (!isLoggedIn) {
     return (
       <CommonModal
         isOpen={isOpen}

--- a/src/components/PublicRoute.tsx
+++ b/src/components/PublicRoute.tsx
@@ -5,23 +5,22 @@ import useModal from '@hooks/useModal';
 import CommonModal from './common/CommonModal';
 
 function PrivateRoute() {
-  const { data: user } = useUser();
-  const isLogin = Boolean(user);
+  const isLoggedIn = useUser();
   const navigate = useNavigate();
   const { isOpen, open, close } = useModal();
 
   useEffect(() => {
-    if (isLogin) {
+    if (isLoggedIn) {
       open();
     }
-  }, [isLogin]);
+  }, [isLoggedIn]);
 
   const handleOkClick = () => {
     close();
     navigate('/', { replace: true });
   };
 
-  if (isLogin) {
+  if (isLoggedIn) {
     return (
       <CommonModal
         isOpen={isOpen}

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -7,14 +7,14 @@ import { useUser } from '@hooks/useUser';
 
 const Header = () => {
   const navigate = useNavigate();
-  const { data: user } = useUser();
-
+  // const { data: user } = useUser();
+  const user = '내 위치';
   return (
     <Container>
       <div className="header">
         <div className="item" onClick={() => navigate('/')}>
           {user ? (
-            <div className="location">{user.town}</div>
+            <div className="location">{user}</div>
           ) : (
             <div className="location non-user">내 위치</div>
           )}

--- a/src/components/common/ProfileSetupForm/KakaoMap/KakaoMap.tsx
+++ b/src/components/common/ProfileSetupForm/KakaoMap/KakaoMap.tsx
@@ -25,7 +25,7 @@ function KakaoMap({
     region_2depth_name: '',
     region_3depth_name: '',
   });
-  const [coordinates, setCoordinates] = useState<Coordinates | null>(null); // [경도, 위도
+  const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
 
   const handleCompleteBtn = () => {
     handleAddressSelect(
@@ -57,10 +57,13 @@ function KakaoMap({
     const geocoder = new kakao.maps.services.Geocoder();
     const longitude = coord.getLng();
     const latitude = coord.getLat();
-    geocoder.coord2Address(longitude, latitude, (result, status) => {
+    geocoder.coord2RegionCode(longitude, latitude, (result, status) => {
       if (status === kakao.maps.services.Status.OK) {
+        //result[0] == 법정동, result[1] == 행정동
+        console.log(result);
+
         const { region_1depth_name, region_2depth_name, region_3depth_name } =
-          result[0].address;
+          result[1];
 
         setAddressInfo({
           region_1depth_name,
@@ -68,8 +71,8 @@ function KakaoMap({
           region_3depth_name,
         });
         setCoordinates({
-          longitude: String(longitude),
-          latitude: String(latitude),
+          longitude,
+          latitude,
         });
       }
     });
@@ -96,12 +99,14 @@ function KakaoMap({
       const geocoder = new kakao.maps.services.Geocoder();
       geocoder.addressSearch(address, (result, status) => {
         if (status === kakao.maps.services.Status.OK) {
+          console.log(result);
+
           const {
             x,
             y,
             region_1depth_name,
             region_2depth_name,
-            region_3depth_name,
+            region_3depth_h_name,
           } = result[0].address;
           const latitude = Number(y);
           const longitude = Number(x);
@@ -110,11 +115,11 @@ function KakaoMap({
           setAddressInfo({
             region_1depth_name,
             region_2depth_name,
-            region_3depth_name,
+            region_3depth_name: region_3depth_h_name,
           });
           setCoordinates({
-            longitude: String(longitude),
-            latitude: String(latitude),
+            longitude,
+            latitude,
           });
           resolve(coords);
         } else {

--- a/src/components/common/ProfileSetupForm/KakaoMap/KakaoMap.tsx
+++ b/src/components/common/ProfileSetupForm/KakaoMap/KakaoMap.tsx
@@ -60,8 +60,6 @@ function KakaoMap({
     geocoder.coord2RegionCode(longitude, latitude, (result, status) => {
       if (status === kakao.maps.services.Status.OK) {
         //result[0] == 법정동, result[1] == 행정동
-        console.log(result);
-
         const { region_1depth_name, region_2depth_name, region_3depth_name } =
           result[1];
 

--- a/src/components/common/ProfileSetupForm/NicknameSetting.tsx
+++ b/src/components/common/ProfileSetupForm/NicknameSetting.tsx
@@ -7,14 +7,12 @@ interface NicknameSettingProps {
   nickname: string;
   error: string | null;
   handleNickname: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleNicknameCheck: () => void;
 }
 
 function NicknameSetting({
   nickname,
   error,
   handleNickname,
-  handleNicknameCheck,
 }: NicknameSettingProps) {
   return (
     <S.Section>
@@ -26,12 +24,6 @@ function NicknameSetting({
           value={nickname}
           onChange={handleNickname}
         />
-        <BlueButton
-          disabled={nickname.length < 2}
-          onClick={handleNicknameCheck}
-        >
-          중복확인
-        </BlueButton>
       </S.InputContainer>
       {error &&
         error

--- a/src/components/common/ProfileSetupForm/ProfileImgSetting.tsx
+++ b/src/components/common/ProfileSetupForm/ProfileImgSetting.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, memo } from 'react';
 import styled from 'styled-components';
 import BigTitle from '@components/common/BigTitle';
+import { useLocation } from 'react-router-dom';
 
 const Container = styled.div`
   margin: 28px 0;
@@ -27,6 +28,7 @@ function ProfileImgSetting({
   handleProfileImgSetting,
 }: IProfileImgSettingProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { pathname } = useLocation();
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
@@ -36,7 +38,12 @@ function ProfileImgSetting({
     }
   };
 
-  const handleImgClick = () => fileInputRef.current?.click();
+  const handleImgClick = () => {
+    if (pathname === '/signup') {
+      return;
+    }
+    fileInputRef.current?.click();
+  };
 
   return (
     <>

--- a/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
+++ b/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
@@ -83,12 +83,9 @@ function ProfileSetupForm({
 
   useEffect(() => {
     const identifier = setTimeout(() => {
-      console.log('first');
       handleNicknameCheck();
     }, 500);
     return () => {
-      console.log('clean up');
-
       clearTimeout(identifier);
     };
   }, [handleNicknameCheck, nicknameState.nickname]);
@@ -124,7 +121,7 @@ function ProfileSetupForm({
             handleSubmit(
               nicknameState.nickname,
               coordinates as Coordinates,
-              selectedAddress.split(' ').slice(-1).toString(),
+              selectedAddress,
               imgFile
             )
           }

--- a/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
+++ b/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
@@ -7,7 +7,6 @@ import NicknameSetting from './NicknameSetting';
 import AddressSetting from './AddressSetting';
 import { Coordinates } from '@/types/UserTypes';
 import { useUser } from '@hooks/useUser';
-import { useCheckNicknameDuplicationMutation } from '@store/api/userApiSlice';
 
 interface IProfileSetupFormProps {
   isEdit?: boolean;

--- a/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
+++ b/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
@@ -38,7 +38,6 @@ function ProfileSetupForm({
     nickname: defaultNickname,
     success: isLogin,
   });
-  const [checkNickname] = useCheckNicknameDuplicationMutation();
   const [nicknameError, setNicknameError] = useState<string>('');
   const [selectedAddress, setSelectedAddress] = useState(defaultAddress || '');
   const [coordinates, setCoordinates] = useState<Coordinates | null>(

--- a/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
+++ b/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
@@ -75,7 +75,7 @@ function ProfileSetupForm({
         nickname: e.target.value,
         success: false,
       });
-      handleNicknameCheck();
+
       if (nicknameError) setNicknameError('');
     },
     [nicknameError]
@@ -84,7 +84,7 @@ function ProfileSetupForm({
   useEffect(() => {
     const identifier = setTimeout(() => {
       handleNicknameCheck();
-    }, 500);
+    }, 300);
     return () => {
       clearTimeout(identifier);
     };

--- a/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
+++ b/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
@@ -111,11 +111,11 @@ function ProfileSetupForm({
           />
         </P.Section>
         <BlueButton
-          disabled={
-            !nicknameState.success ||
-            selectedAddress.length < 0 ||
-            coordinates === null
-          }
+          // disabled={
+          //   !nicknameState.success ||
+          //   selectedAddress.length < 0 ||
+          //   coordinates === null
+          // }
           maxWidth="100%"
           onClick={() =>
             handleSubmit(

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,9 +1,13 @@
 import { tokenStorage } from '@utils/tokenStorage';
 import { useGetUserInfoQuery } from '@store/api/userApiSlice';
+import { useSelector } from 'react-redux';
+import { RootState } from '@store/types';
 
 export const useUser = () => {
-  const token = tokenStorage.getAccessToken();
-  const result = useGetUserInfoQuery(undefined, { skip: !token });
+  // const token = tokenStorage.getAccessToken();
+  // const result = useGetUserInfoQuery(undefined, { skip: !token });
 
-  return result;
+  const isLoggedIn = useSelector((state: RootState) => state.auth.isLoggedIn);
+
+  return isLoggedIn;
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,15 +4,15 @@ import { Provider } from 'react-redux';
 import { store } from './store/store';
 import App from './App.tsx';
 
-if (import.meta.env.DEV) {
-  const { worker } = await import('./mocks/browser');
-  worker.start();
-}
+// if (import.meta.env.DEV) {
+//   const { worker } = await import('./mocks/browser');
+//   worker.start();
+// }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>
+  // <React.StrictMode>
+  <Provider store={store}>
+    <App />
+  </Provider>
+  // </React.StrictMode>
 );

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -35,19 +35,19 @@ export const handlers = [
     );
   }),
 
-  rest.post('/api/login/kakao', (req, res, ctx) => {
-    // 신규 유저일 경우
-    return res(
-      ctx.status(301),
-      ctx.json({
-        authId: '123',
-        authType: 'KAKAO',
-        nickname: '거래왕',
-        profileImage:
-          'https://static.wanted.co.kr/images/events/1633/f85834e9.jpg',
-      })
-    );
-  }),
+  // rest.post('/api/login/kakao', (req, res, ctx) => {
+  //   // 신규 유저일 경우
+  //   return res(
+  //     ctx.status(301),
+  //     ctx.json({
+  //       authId: '123',
+  //       authType: 'KAKAO',
+  //       nickname: '거래왕',
+  //       profileImage:
+  //         'https://static.wanted.co.kr/images/events/1633/f85834e9.jpg',
+  //     })
+  //   );
+  // }),
 
   rest.post('/api/login/naver', (req, res, ctx) => {
     // 로그인 성공시

--- a/src/store/api/apiSlice.ts
+++ b/src/store/api/apiSlice.ts
@@ -24,9 +24,6 @@ const baseQuery = fetchBaseQuery({
     }
     return headers;
   },
-  validateStatus: (response) =>
-    (response.status >= 200 && response.status <= 301) ||
-    response.status === 301,
 });
 
 const baseQueryWithIntercept: BaseQueryFn<
@@ -52,10 +49,7 @@ const baseQueryWithIntercept: BaseQueryFn<
     );
 
     // 정상적으로 새로운 Access Token을 발급받았을 경우
-    if (refreshResult.meta.response.ok) {
-      if (refreshResult.meta.response.status !== 201) {
-        handleError(refreshResult.meta.response.status);
-      }
+    if (refreshResult.meta.response.status === 201) {
       const newAccessToken = (refreshResult.data as RefreshTokenResponse)
         .accessToken;
       tokenStorage.setAccessToken(newAccessToken);

--- a/src/store/api/apiSlice.ts
+++ b/src/store/api/apiSlice.ts
@@ -7,14 +7,18 @@ import type {
 import { tokenStorage } from '@utils/tokenStorage';
 import { RefreshTokenResponse } from '@/types/AuthTypes';
 
+export const SERVER_URL = import.meta.env.VITE_SERVER_URL;
+
 const handleError = (statusCode: number) => {
   alert('다시 로그인해주세요. (토큰 만료) status:' + statusCode);
   // Todo: api.dispatch(logoutUser());
 };
 
 const baseQuery = fetchBaseQuery({
-  baseUrl: '/api',
-  prepareHeaders: (headers) => {
+  baseUrl: SERVER_URL + '/api',
+  prepareHeaders: (headers, { endpoint }) => {
+    if (endpoint === 'login') return;
+
     const accessToken = tokenStorage.getAccessToken();
     // Access Token이 있으면 API 호출 시 Header에 추가
     if (accessToken) {
@@ -34,6 +38,7 @@ const baseQueryWithIntercept: BaseQueryFn<
 > = async (args, api, extraOptions) => {
   let result = await baseQuery(args, api, extraOptions);
   // Access Token이 만료되었을 경우
+  console.log(result);
   if (result.error && result.error.status === 401) {
     const refreshToken = tokenStorage.getRefreshToken();
     // Refresh Token으로 새로운 Access Token을 발급받음
@@ -48,6 +53,7 @@ const baseQueryWithIntercept: BaseQueryFn<
       api,
       extraOptions
     );
+
     // 정상적으로 새로운 Access Token을 발급받았을 경우
     if (refreshResult.meta.response.ok) {
       if (refreshResult.meta.response.status !== 201) {

--- a/src/store/api/apiSlice.ts
+++ b/src/store/api/apiSlice.ts
@@ -5,7 +5,7 @@ import type {
   FetchBaseQueryError,
 } from '@reduxjs/toolkit/query';
 import { tokenStorage } from '@utils/tokenStorage';
-import { RefreshTokenResponse } from '@/types/AuthTypes';
+import { AccessTokenToRefreshTokenResponse } from '@/types/AuthTypes';
 import { logOut } from '@store/slices/authSlice';
 
 export const SERVER_URL = import.meta.env.VITE_SERVER_URL;
@@ -51,8 +51,9 @@ const baseQueryWithIntercept: BaseQueryFn<
 
     // 정상적으로 새로운 Access Token을 발급받았을 경우
     if (refreshResult?.data) {
-      const newAccessToken = (refreshResult.data as RefreshTokenResponse)
-        .accessToken;
+      const newAccessToken = (
+        refreshResult.data as AccessTokenToRefreshTokenResponse
+      ).data.split(' ')[1];
       tokenStorage.setAccessToken(newAccessToken);
       // 새로운 Access Token으로 다시 기존 API 호출
       result = await baseQuery(args, api, extraOptions);

--- a/src/store/api/apiSlice.ts
+++ b/src/store/api/apiSlice.ts
@@ -16,9 +16,7 @@ const handleError = (statusCode: number) => {
 
 const baseQuery = fetchBaseQuery({
   baseUrl: SERVER_URL + '/api',
-  prepareHeaders: (headers, { endpoint }) => {
-    if (endpoint === 'login') return;
-
+  prepareHeaders: (headers) => {
     const accessToken = tokenStorage.getAccessToken();
     // Access Token이 있으면 API 호출 시 Header에 추가
     if (accessToken) {
@@ -38,7 +36,6 @@ const baseQueryWithIntercept: BaseQueryFn<
 > = async (args, api, extraOptions) => {
   let result = await baseQuery(args, api, extraOptions);
   // Access Token이 만료되었을 경우
-  console.log(result);
   if (result.error && result.error.status === 401) {
     const refreshToken = tokenStorage.getRefreshToken();
     // Refresh Token으로 새로운 Access Token을 발급받음

--- a/src/store/api/apiSlice.ts
+++ b/src/store/api/apiSlice.ts
@@ -11,6 +11,7 @@ export const SERVER_URL = import.meta.env.VITE_SERVER_URL;
 
 const handleError = (statusCode: number) => {
   alert('다시 로그인해주세요. (토큰 만료) status:' + statusCode);
+  tokenStorage.clearTokens();
   // Todo: api.dispatch(logoutUser());
 };
 
@@ -34,6 +35,7 @@ const baseQueryWithIntercept: BaseQueryFn<
   let result = await baseQuery(args, api, extraOptions);
   // Access Token이 만료되었을 경우
   if (result.error && result.error.status === 401) {
+    tokenStorage.removeAccessToken();
     const refreshToken = tokenStorage.getRefreshToken();
     // Refresh Token으로 새로운 Access Token을 발급받음
     const refreshResult = await baseQuery(

--- a/src/store/api/authApiSlice.ts
+++ b/src/store/api/authApiSlice.ts
@@ -29,7 +29,6 @@ export const authApiSlice = apiSlice.injectEndpoints({
           const { accessToken, refreshToken } =
             response.data as LoginResponse['data'];
           tokenStorage.setTokens({ accessToken, refreshToken });
-
           return response;
         }
 
@@ -43,7 +42,6 @@ export const authApiSlice = apiSlice.injectEndpoints({
         body,
       }),
       transformResponse: (response: LoginResponse) => {
-        console.log(response);
         const { accessToken, refreshToken } = response.data;
         tokenStorage.setTokens({ accessToken, refreshToken });
         return response;

--- a/src/store/api/authApiSlice.ts
+++ b/src/store/api/authApiSlice.ts
@@ -17,8 +17,8 @@ export const authApiSlice = apiSlice.injectEndpoints({
       { serviceName: OAuthServiceType; code: string }
     >({
       query: ({ serviceName, code }) => ({
-        url: `/login/${serviceName}?authorizationCode=${code}${
-          serviceName === 'naver' && '&state=true'
+        url: `users/login/${serviceName}?authorizationCode=${code}${
+          serviceName === 'naver' ? 'naver' : ''
         }`,
         method: 'POST',
       }),
@@ -40,7 +40,7 @@ export const authApiSlice = apiSlice.injectEndpoints({
     }),
     signUp: builder.mutation<LoginResponse, RegisterRequest>({
       query: (body) => ({
-        url: '/register',
+        url: 'users/register',
         method: 'POST',
         body,
       }),

--- a/src/store/api/authApiSlice.ts
+++ b/src/store/api/authApiSlice.ts
@@ -8,7 +8,6 @@ import { apiSlice } from '@store/api/apiSlice';
 import { tokenStorage } from '@utils/tokenStorage';
 
 const HTTP_STATUS_OK = 200;
-const HTTP_STATUS_MOVED_PERMANENTLY = 301;
 
 export const authApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
@@ -27,12 +26,11 @@ export const authApiSlice = apiSlice.injectEndpoints({
         meta: { response: Response }
       ) => {
         if (meta.response.status === HTTP_STATUS_OK) {
-          const { accessToken, refreshToken } = response as LoginResponse;
+          const { accessToken, refreshToken } =
+            response.data as LoginResponse['data'];
           tokenStorage.setTokens({ accessToken, refreshToken });
+
           return response;
-        } else if (meta.response.status === HTTP_STATUS_MOVED_PERMANENTLY) {
-          const data = response as NewUserResponse;
-          return { ...data, code: HTTP_STATUS_MOVED_PERMANENTLY };
         }
 
         throw new Error(`Unexpected response status: ${meta.response.status}`);
@@ -45,7 +43,8 @@ export const authApiSlice = apiSlice.injectEndpoints({
         body,
       }),
       transformResponse: (response: LoginResponse) => {
-        const { accessToken, refreshToken } = response;
+        console.log(response);
+        const { accessToken, refreshToken } = response.data;
         tokenStorage.setTokens({ accessToken, refreshToken });
         return response;
       },

--- a/src/store/api/userApiSlice.ts
+++ b/src/store/api/userApiSlice.ts
@@ -6,13 +6,6 @@ export const userApiSlice = apiSlice.injectEndpoints({
     getUserInfo: builder.query<User, void>({
       query: () => '/user/info',
     }),
-    checkNicknameDuplication: builder.mutation({
-      query: (nickname) => ({
-        url: '/user/nickname',
-        method: 'POST',
-        body: { nickname },
-      }),
-    }),
     updateUserInfo: builder.mutation({
       query: (body) => ({
         url: '/user/update',
@@ -23,8 +16,4 @@ export const userApiSlice = apiSlice.injectEndpoints({
   }),
 });
 
-export const {
-  useGetUserInfoQuery,
-  useCheckNicknameDuplicationMutation,
-  useUpdateUserInfoMutation,
-} = userApiSlice;
+export const { useGetUserInfoQuery, useUpdateUserInfoMutation } = userApiSlice;

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -1,0 +1,30 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { tokenStorage } from '@utils/tokenStorage';
+
+interface AuthState {
+  isLoggedIn: boolean;
+}
+
+const initialState: AuthState = {
+  isLoggedIn: Boolean(tokenStorage.getAccessToken()),
+};
+
+// Todo: 동네 or 유저 조회 api 나오면 수정 필요
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    login: (state: AuthState) => {
+      state.isLoggedIn = true;
+    },
+    logOut: (state: AuthState) => {
+      state.isLoggedIn = false;
+      tokenStorage.clearTokens();
+    },
+  },
+});
+
+export const { login, logOut } = authSlice.actions;
+
+export default authSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -4,10 +4,12 @@ import WritePostSlice from './slices/WritePostSlice';
 import ChatSlice from './slices/ChatSlice';
 import CheckboxSlice from './slices/checkboxSlice';
 import { apiSlice } from '@store/api/apiSlice';
+import authSlice from './slices/authSlice';
 
 export const store = configureStore({
   reducer: {
     [apiSlice.reducerPath]: apiSlice.reducer,
+    auth: authSlice,
     createComment: createCommentSlice,
     WritePost: WritePostSlice,
     chat: ChatSlice,

--- a/src/types/AuthTypes.ts
+++ b/src/types/AuthTypes.ts
@@ -38,8 +38,8 @@ export interface RegisterRequest {
   };
 }
 
-export interface RefreshTokenResponse {
-  accessToken: string;
+export interface AccessTokenToRefreshTokenResponse {
+  data: string;
   code: number;
   message: string;
 }

--- a/src/types/AuthTypes.ts
+++ b/src/types/AuthTypes.ts
@@ -14,10 +14,13 @@ export interface LoginResponse {
 
 export interface NewUserResponse {
   code?: number;
-  authId: string;
-  authType: OAuthServiceType;
-  nickname: string;
-  profileImage: string;
+  message: string;
+  data: {
+    authId: string;
+    authType: OAuthServiceType;
+    nickname: string;
+    profileImage: string;
+  };
 }
 
 export interface RegisterRequest {

--- a/src/types/AuthTypes.ts
+++ b/src/types/AuthTypes.ts
@@ -8,8 +8,10 @@ export type OAuthServiceType =
 export interface LoginResponse {
   code: number;
   message: string;
-  accessToken: string;
-  refreshToken: string;
+  data: {
+    accessToken: string;
+    refreshToken: string;
+  };
 }
 
 export interface NewUserResponse {
@@ -28,9 +30,12 @@ export interface RegisterRequest {
   authType: OAuthServiceType;
   nickname: string;
   profileImage: string;
-  imageFile: File;
-  latitude: string;
-  longitude: string;
+  addressRequest: {
+    name: string;
+    latitude: number;
+    longitude: number;
+    type: string;
+  };
 }
 
 export interface RefreshTokenResponse {

--- a/src/types/UserTypes.ts
+++ b/src/types/UserTypes.ts
@@ -1,6 +1,6 @@
 export interface Coordinates {
-  latitude: string;
-  longitude: string;
+  latitude: number;
+  longitude: number;
 }
 export type GradeType = 'one' | 'two' | 'three' | 'four' | null;
 
@@ -8,7 +8,7 @@ export interface User {
   id: string;
   profile_image: string;
   nickname: string;
-  coordinates: { latitude: string; longitude: string };
+  coordinates: { latitude: number; longitude: number };
   grade: GradeType;
   town: string;
 }

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -22,9 +22,13 @@ const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN);
 
 const getRefreshToken = () => Cookies.get(REFRESH_TOKEN);
 
+const removeAccessToken = () => localStorage.removeItem(ACCESS_TOKEN);
+
+const removeRefreshToken = () => Cookies.remove(REFRESH_TOKEN);
+
 const clearTokens = () => {
-  localStorage.removeItem(ACCESS_TOKEN);
-  Cookies.remove(REFRESH_TOKEN);
+  removeAccessToken();
+  removeRefreshToken();
 };
 
 const setTokens = ({ accessToken, refreshToken }: TokensType) => {
@@ -38,5 +42,7 @@ export const tokenStorage = {
   setTokens,
   getAccessToken,
   getRefreshToken,
+  removeAccessToken,
+  removeRefreshToken,
   clearTokens,
 };

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -15,6 +15,7 @@ const setRefreshToken = (refreshToken: string) =>
   Cookies.set(REFRESH_TOKEN, refreshToken, {
     secure: import.meta.env.PROD,
     sameSite: 'strict',
+    expires: 10080 / 1440,
   });
 
 const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN);


### PR DESCRIPTION
## 작업 목록
1. Refresh Token Cookie 만료 기한 설정
2. 카카오 로그인 및 회원가입 API 연동
3.  닉네임 중복 확인 로직 변경
     - (중복 확인 버튼 -> 가입하기 버튼 클릭 시 확인)
4. 로그인 유지 관련 임시 코드 추가 
    - authSlice의 isLoggedIn으로 로그인 상태 판별
    - 추후 회원 정보 관련 API 개발 완료 되면 수정 필요

## 참고 사항
1. 현재 프로젝트에 있는 env: VITE_KAKAO_REST_API_KEY -> 다은님이 알려주신 카카오 클라이언트 id로 변경 필요합니다.
2. VITE_SERVER_URL=서버주소      env 생성 필요합니다.
3. RTK query 사용하실때 ```apiSlice.injectEndpoints``` 하셔서 사용하시면 됩니다!
- api 요청시 해당 요청 이전에 header에 access token 추가 하는 interceptor입니다
- [사용법 참고](https://redux-toolkit.js.org/rtk-query/usage/code-splitting) 및 ```store/api``` 폴더 에 api mocking할 때 작성된 코드들이 있어서 참고하시면 편하실 것 같아요!