### PR TITLE
[회원 인증] 회원가입 API 변경으로 인한 회원가입 로직 수정

### DIFF
--- a/src/Pages/SingUp/SignUp.tsx
+++ b/src/Pages/SingUp/SignUp.tsx
@@ -40,16 +40,18 @@ function SignUp() {
 
   const handleError = (error: any) => {
     console.error(error);
-    alert('회원가입에 실패했습니다. error: ' + error);
+    alert(
+      '회원가입에 실패했습니다. 다시 시도 해주세요. error: ' + error.message
+    );
     navigate('/auth', { replace: true });
   };
 
   const handleSubmit = async (
     nickname: string,
-    coordinates: Coordinates,
     address: string,
     profileImgFile: File | null
   ) => {
+    const [city, name] = address.split(' ');
     const signUpData = {
       authId,
       authType,
@@ -57,9 +59,8 @@ function SignUp() {
       profileImage,
       // imageFile: profileImgFile,
       addressRequest: {
-        name: address,
-        longitude: coordinates.latitude,
-        latitude: coordinates.longitude,
+        city,
+        name,
         type: 'main',
       },
     };

--- a/src/components/common/ProfileSetupForm/AddressSetting.tsx
+++ b/src/components/common/ProfileSetupForm/AddressSetting.tsx
@@ -7,7 +7,6 @@ import BlueButton from '@components/common/Buttons/BlueButton';
 import { size } from '@styles/theme';
 import CommonHeader from '@components/common/CommonHeader/CommonHeader';
 import ActionButton from '@components/common/Buttons/ActionButton';
-import { Coordinates } from '@/types/UserTypes';
 import KakaoMap from './KakaoMap';
 
 const MapContainer = styled.div`
@@ -34,13 +33,11 @@ const MapContainer = styled.div`
 interface IAddressSettingProps {
   selectedAddress: string;
   handleAddressSelect: (address: string) => void;
-  handleCoordinates: (coordinates: Coordinates) => void;
 }
 
 function AddressSetting({
   selectedAddress,
   handleAddressSelect,
-  handleCoordinates,
 }: IAddressSettingProps) {
   const open = useDaumPostcodePopup();
 
@@ -63,7 +60,7 @@ function AddressSetting({
   };
 
   const handleSearchBtnClick = () => {
-    open({ onComplete: handleComplete });
+    open({ onComplete: handleComplete, shorthand: false });
   };
 
   return (
@@ -100,7 +97,6 @@ function AddressSetting({
           <KakaoMap
             selectedAddress={selectedAddress}
             handleAddressSelect={handleAddressSelect}
-            handleCoordinates={handleCoordinates}
             closeAddressModal={closeAddressModal}
           />
         </MapContainer>

--- a/src/components/common/ProfileSetupForm/KakaoMap/KakaoMap.tsx
+++ b/src/components/common/ProfileSetupForm/KakaoMap/KakaoMap.tsx
@@ -3,35 +3,29 @@ import * as K from './KakaoMapStyles';
 import useCurrentPosition from '@/hooks/useCurrentPosition';
 import CurrentLocation from '@components/common/ProfileSetupForm/CurrentLocation';
 import SetCurrentLocationBtn from '@components/common/ProfileSetupForm/SetCurrentLocationBtn';
-import { Coordinates } from '@/types/UserTypes';
 
 interface IKakaoMapProps {
   selectedAddress: string;
   handleAddressSelect: (address: string) => void;
-  handleCoordinates: (coordinates: Coordinates) => void;
   closeAddressModal: () => void;
 }
 
 function KakaoMap({
   selectedAddress,
   handleAddressSelect,
-  handleCoordinates,
   closeAddressModal,
 }: IKakaoMapProps) {
   const container = useRef<HTMLDivElement>(null);
   const currentPosition = useCurrentPosition();
   const [addressInfo, setAddressInfo] = useState({
     region_1depth_name: '',
-    region_2depth_name: '',
     region_3depth_name: '',
   });
-  const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
 
   const handleCompleteBtn = () => {
     handleAddressSelect(
-      `${addressInfo.region_1depth_name} ${addressInfo.region_2depth_name} ${addressInfo.region_3depth_name}`
+      `${addressInfo.region_1depth_name} ${addressInfo.region_3depth_name}`
     );
-    handleCoordinates(coordinates as Coordinates);
     closeAddressModal();
   };
 
@@ -60,17 +54,11 @@ function KakaoMap({
     geocoder.coord2RegionCode(longitude, latitude, (result, status) => {
       if (status === kakao.maps.services.Status.OK) {
         //result[0] == 법정동, result[1] == 행정동
-        const { region_1depth_name, region_2depth_name, region_3depth_name } =
-          result[1];
+        const { region_1depth_name, region_3depth_name } = result[1];
 
         setAddressInfo({
           region_1depth_name,
-          region_2depth_name,
           region_3depth_name,
-        });
-        setCoordinates({
-          longitude,
-          latitude,
         });
       }
     });
@@ -97,27 +85,13 @@ function KakaoMap({
       const geocoder = new kakao.maps.services.Geocoder();
       geocoder.addressSearch(address, (result, status) => {
         if (status === kakao.maps.services.Status.OK) {
-          console.log(result);
-
-          const {
-            x,
-            y,
-            region_1depth_name,
-            region_2depth_name,
-            region_3depth_h_name,
-          } = result[0].address;
+          const { x, y, region_3depth_h_name } = result[0].address;
           const latitude = Number(y);
           const longitude = Number(x);
           const coords = new kakao.maps.LatLng(latitude, longitude);
-
           setAddressInfo({
-            region_1depth_name,
-            region_2depth_name,
+            region_1depth_name: address.split(' ')[0],
             region_3depth_name: region_3depth_h_name,
-          });
-          setCoordinates({
-            longitude,
-            latitude,
           });
           resolve(coords);
         } else {
@@ -153,7 +127,7 @@ function KakaoMap({
     <K.Container ref={container}>
       <SetCurrentLocationBtn onClick={displayMapBasedOnCurrentPosition} />
       <CurrentLocation
-        addressInfo={`${addressInfo.region_1depth_name} ${addressInfo.region_2depth_name} ${addressInfo.region_3depth_name}`}
+        addressInfo={`${addressInfo.region_1depth_name} ${addressInfo.region_3depth_name}`}
         handleCompleteBtn={handleCompleteBtn}
       />
     </K.Container>

--- a/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
+++ b/src/components/common/ProfileSetupForm/ProfileSetupForm.tsx
@@ -5,17 +5,14 @@ import BlueButton from '@components/common/Buttons/BlueButton';
 import ProfileImgSetting from './ProfileImgSetting';
 import NicknameSetting from './NicknameSetting';
 import AddressSetting from './AddressSetting';
-import { Coordinates } from '@/types/UserTypes';
 
 interface IProfileSetupFormProps {
   isEdit?: boolean;
   defaultProfileImgSrc: string;
   defaultNickname: string;
-  defaultCoordinates?: Coordinates;
   defaultAddress?: string;
   handleSubmit: (
     nickname: string,
-    Coordinates: Coordinates,
     address: string,
     profileImg: File | null
   ) => Promise<void>;
@@ -25,7 +22,6 @@ function ProfileSetupForm({
   isEdit = false,
   defaultProfileImgSrc,
   defaultNickname,
-  defaultCoordinates,
   defaultAddress,
   handleSubmit,
 }: IProfileSetupFormProps) {
@@ -34,15 +30,9 @@ function ProfileSetupForm({
   const [nickname, setNickname] = useState(defaultNickname);
   const [nicknameError, setNicknameError] = useState<string>('');
   const [selectedAddress, setSelectedAddress] = useState(defaultAddress || '');
-  const [coordinates, setCoordinates] = useState<Coordinates | null>(
-    defaultCoordinates || null
-  );
 
   const handleAddressSelect = useCallback((address: string) => {
     setSelectedAddress(address);
-  }, []);
-  const handleCoordinates = useCallback((coordinates: Coordinates) => {
-    setCoordinates(coordinates);
   }, []);
 
   const handleProfileImgSetting = useCallback(
@@ -97,22 +87,12 @@ function ProfileSetupForm({
           <AddressSetting
             selectedAddress={selectedAddress}
             handleAddressSelect={handleAddressSelect}
-            handleCoordinates={handleCoordinates}
           />
         </P.Section>
         <BlueButton
-          disabled={
-            nicknameError.length > 1 || !nickname || coordinates === null
-          }
+          disabled={nicknameError.length > 1 || !nickname}
           maxWidth="100%"
-          onClick={() =>
-            handleSubmit(
-              nickname,
-              coordinates as Coordinates,
-              selectedAddress,
-              imgFile
-            )
-          }
+          onClick={() => handleSubmit(nickname, selectedAddress, imgFile)}
         >
           완료
         </BlueButton>

--- a/src/store/api/apiSlice.ts
+++ b/src/store/api/apiSlice.ts
@@ -5,7 +5,7 @@ import type {
   FetchBaseQueryError,
 } from '@reduxjs/toolkit/query';
 import { tokenStorage } from '@utils/tokenStorage';
-import { AccessTokenToRefreshTokenResponse } from '@/types/AuthTypes';
+import { TokensResponse } from '@/types/AuthTypes';
 import { logOut } from '@store/slices/authSlice';
 
 export const SERVER_URL = import.meta.env.VITE_SERVER_URL;
@@ -51,9 +51,9 @@ const baseQueryWithIntercept: BaseQueryFn<
 
     // 정상적으로 새로운 Access Token을 발급받았을 경우
     if (refreshResult?.data) {
-      const newAccessToken = (
-        refreshResult.data as AccessTokenToRefreshTokenResponse
-      ).data.split(' ')[1];
+      const newAccessToken = (refreshResult.data as TokensResponse).data.split(
+        ' '
+      )[1];
       tokenStorage.setAccessToken(newAccessToken);
       // 새로운 Access Token으로 다시 기존 API 호출
       result = await baseQuery(args, api, extraOptions);

--- a/src/store/api/authApiSlice.ts
+++ b/src/store/api/authApiSlice.ts
@@ -2,7 +2,7 @@ import {
   LoginResponse,
   NewUserResponse,
   OAuthServiceType,
-  RegisterRequest,
+  IRegisterRequest,
 } from '@/types/AuthTypes';
 import { apiSlice } from '@store/api/apiSlice';
 import { tokenStorage } from '@utils/tokenStorage';
@@ -35,7 +35,7 @@ export const authApiSlice = apiSlice.injectEndpoints({
         throw new Error(`Unexpected response status: ${meta.response.status}`);
       },
     }),
-    signUp: builder.mutation<LoginResponse, RegisterRequest>({
+    signUp: builder.mutation<LoginResponse, IRegisterRequest>({
       query: (body) => ({
         url: 'users/register',
         method: 'POST',

--- a/src/store/api/authApiSlice.ts
+++ b/src/store/api/authApiSlice.ts
@@ -26,6 +26,9 @@ export const authApiSlice = apiSlice.injectEndpoints({
         meta: { response: Response }
       ) => {
         if (meta.response.status === HTTP_STATUS_OK) {
+          if (response.message.includes('신규 회원')) {
+            return response;
+          }
           const { accessToken, refreshToken } =
             response.data as LoginResponse['data'];
           tokenStorage.setTokens({ accessToken, refreshToken });

--- a/src/types/AuthTypes.ts
+++ b/src/types/AuthTypes.ts
@@ -30,9 +30,8 @@ export interface IRegisterRequest {
   nickname: string;
   profileImage: string;
   addressRequest: {
+    city: string;
     name: string;
-    latitude: number;
-    longitude: number;
     type: string;
   };
 }

--- a/src/types/AuthTypes.ts
+++ b/src/types/AuthTypes.ts
@@ -5,27 +5,26 @@ export type OAuthServiceType =
   | 'google'
   | 'naver'
   | 'kakao';
-export interface LoginResponse {
+
+export interface IResponse<T> {
   code: number;
   message: string;
-  data: {
-    accessToken: string;
-    refreshToken: string;
-  };
+  data: T;
 }
 
-export interface NewUserResponse {
-  code?: number;
-  message: string;
-  data: {
-    authId: string;
-    authType: OAuthServiceType;
-    nickname: string;
-    profileImage: string;
-  };
+export interface ITokens {
+  accessToken: string;
+  refreshToken: string;
 }
 
-export interface RegisterRequest {
+export interface INewUser {
+  authId: string;
+  authType: OAuthServiceType;
+  nickname: string;
+  profileImage: string;
+}
+
+export interface IRegisterRequest {
   authId: string;
   authType: OAuthServiceType;
   nickname: string;
@@ -38,8 +37,6 @@ export interface RegisterRequest {
   };
 }
 
-export interface AccessTokenToRefreshTokenResponse {
-  data: string;
-  code: number;
-  message: string;
-}
+export type LoginResponse = IResponse<ITokens>;
+export type TokensResponse = IResponse<string>;
+export type NewUserResponse = IResponse<INewUser>;


### PR DESCRIPTION
회원가입 API 명세서의 변동에 따라서 내부 로직도 수정했습니다.
전
```
addressRequest: {
name: address,
longitude: coordinates.latitude,
latitude: coordinates.longitude,
type: 'main',
},
```
후
```
"addressRequest": {
"city": "string",
"name": "string",
"type": "string"
}
```
- '시'와 '행정동'만 필요로 함

### 작업 내용
- 중복되는 타입 제너릭 사용하여 중복되는 코드 개선
- 좌표는 이제 사용되지 않기에 관련 좌표 관련 코드 삭제
- 신규 회원인데 토큰을 저장하는 로직이 진행되는 문제 해결