### PR TITLE
[게시물 상세 페이지] 상세 조회하기 기능 구현 (API 연결)

### DIFF
--- a/src/Pages/Articles/Articles.tsx
+++ b/src/Pages/Articles/Articles.tsx
@@ -83,7 +83,6 @@ function Articles() {
 
   const [deletePost, { isLoading: isDeletePostLoading }] =
     useDeletePostMutation();
-  console.log(post);
 
   const { isOpen, open, close } = useModal();
   const {

--- a/src/Pages/Articles/Articles.tsx
+++ b/src/Pages/Articles/Articles.tsx
@@ -157,6 +157,7 @@ function Articles() {
       <PostActionButtons
         isOfferPost={post.tradeType === TRADE_TYPE.OFFER}
         isOwner={isOwner}
+        isEnded={new Date(post?.closeAt).getTime() < Date.now()}
         onChatButtonClick={
           post.tradeType === TRADE_TYPE.OFFER
             ? chatToOfferedUserModalOpen

--- a/src/Pages/Articles/Articles.tsx
+++ b/src/Pages/Articles/Articles.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Swiper, SwiperSlide } from 'swiper/react';
 import * as A from './ArticlesStyles';
 import CommonHeader from '@components/common/CommonHeader/CommonHeader';
 import WriterProfile from '@/components/Articles/WriterProfile';
@@ -16,6 +15,14 @@ import defaultCharacterImg from '@Assets/Character_Icons/Character_circle.svg';
 import ConfirmModal from '@components/common/ConfirmModal';
 import ChatToOfferedUserContainer from '@components/Articles/ChatToOfferedUserContainer';
 import ProductImagesContainer from '@components/Articles/ProductImagesContainer';
+import {
+  useDeletePostMutation,
+  useGetPostDetailQuery,
+} from '@store/api/postApiSlice';
+import { useUser } from '@hooks/useUser';
+import Spinner from '@components/Auth/Spinner';
+import { format, parseISO } from 'date-fns';
+import { TRADE_TYPE } from '@/types/PostTypes';
 
 // 더미데이터
 const offers: OfferPostTypes[] = [
@@ -66,6 +73,18 @@ const offers: OfferPostTypes[] = [
 
 function Articles() {
   const navigate = useNavigate();
+  const { data: { data: user } = {} } = useUser();
+  // Todo: 게시물 생성 완료되면 해당 게시물 id로 상세 정보 가져오기
+  const { data: post, isLoading, isError } = useGetPostDetailQuery('13');
+
+  if (isError) {
+    navigate('/error', { replace: true });
+  }
+
+  const [deletePost, { isLoading: isDeletePostLoading }] =
+    useDeletePostMutation();
+  console.log(post);
+
   const { isOpen, open, close } = useModal();
   const {
     isOpen: isDeleteModalOpen,
@@ -77,53 +96,29 @@ function Articles() {
     open: chatToOfferedUserModalOpen,
     close: chatToOfferedUserModalClose,
   } = useModal();
-  const timeDifference = useTimeDiff(new Date('2023-08-08T23:00:00')); // Todo: createdAt으로 변경
+  const timeDifference = post?.createdAt ? useTimeDiff(post.createdAt) : null;
   const { id } = useParams();
-
-  const [isOfferPost, setIsOfferPost] = useState(false); // Todo: API 명세서 나오면 수정 필요 (1:1, offerPost 구분)
-  const isOwner = true; // Todo: API 명세서 나오면 수정 필요 (게시글 작성자 id와 로그인된 id로 구분)
+  const [isOwner, setIsOwner] = useState(false);
 
   const handleDeletePost = async () => {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        console.log(id, '삭제');
-        resolve(null);
-      }, 2000);
-    });
-  };
-
-  const handleDeleteComplete = () => {
-    navigate('/', { replace: true });
+    try {
+      await deletePost('13').unwrap();
+      navigate('/', { replace: true });
+    } catch (error: any) {
+      throw new Error(error.data.message);
+    }
   };
 
   // 1:1 거래일 시 채팅하기 버튼 클릭 시
   const handleDirectChatInitiation = () => {};
 
-  // Todo: id를 통해 해당 게시글 정보 가져오기
   useEffect(() => {
-    // 더미데이터: 임시 id로 짝수면 오퍼 게시글, 홀수면 1:1 게시글
-    if (Number(id) % 2 === 0) {
-      setIsOfferPost(true);
+    if (post && user) {
+      setIsOwner(post.writer.id === user.id);
     }
-  }, []);
+  }, [post, user]);
 
-  //Todo : 게시글 정보 --> 수정게시물에 props로 전달
-  const ProductInfoData = {
-    exChangeType: '물물',
-    isOfferPost: isOfferPost, //오퍼 혹은 1:1;
-    title: '여성용 나비 선글라스',
-    category: '의류',
-    deadLine: '2023년 08월 17일',
-    desiredCategory: '의류',
-    tradeTime: '오전(09시~12시)',
-    price: [21000, 24000],
-    description: '2년 간 사용했고, 기스가 좀 있습니다.',
-  };
-
-  const dumyImages = [
-    'https://health.chosun.com/site/data/img_dir/2021/06/08/2021060801363_0.jpg',
-    'https://health.chosun.com/site/data/img_dir/2021/06/08/2021060801363_0.jpg',
-  ];
+  if (isLoading) return <Spinner />;
 
   return (
     <>
@@ -131,44 +126,48 @@ function Articles() {
         상세 페이지
       </CommonHeader>
       <A.Container>
-        {dumyImages.length > 0 && (
-          <ProductImagesContainer images={dumyImages} />
+        {post?.images.length > 0 && (
+          <ProductImagesContainer images={post.images} />
         )}
         <A.ContentsContainer>
           <WriterProfile
-            profileImg={defaultCharacterImg} // Todo: ImgSrc가 있으면 해당 이미지 아니면 기본 이미지
-            nickname="동그란 딸기"
-            location="한강로동"
+            profileImg={post?.writer.profileImage || defaultCharacterImg}
+            nickname={post?.writer.nickname}
+            location={
+              post?.writer.address.hdongName || post?.writer.address.eupMyeon
+            }
             rating="three"
           />
           <ProductInfo
-            title="여성용 나비 선글라스"
-            category="의류"
+            title={post?.title}
+            category={post?.wishCategory}
             uploadTime={timeDifference}
-            deadLine="2023년 08월 17일"
-            desiredCategory="의류"
-            tradeTime="오전(09시~12시)"
-            price="21,000~24,000"
-            description="2년 간 사용했고, 기스가 좀 있습니다."
+            deadLine={format(parseISO(post?.closeAt), 'yyyy년 MM월 dd일')}
+            desiredCategory={post?.provisionCategory}
+            tradeTime={post?.tradeTime}
+            price={post?.suggestedPrice}
+            description={post?.content}
           />
           <LikeAndComment likeCount="3" commentCount="3" />
-          {isOfferPost && <OfferItemLists offers={offers} isOwner={isOwner} />}
+          {post.tradeType === TRADE_TYPE.OFFER && (
+            <OfferItemLists offers={offers} isOwner={isOwner} />
+          )}
         </A.ContentsContainer>
       </A.Container>
       <PostActionButtons
-        isOfferPost={isOfferPost}
+        isOfferPost={post.tradeType === TRADE_TYPE.OFFER}
         isOwner={isOwner}
         onChatButtonClick={
-          isOfferPost ? chatToOfferedUserModalOpen : handleDirectChatInitiation
+          post.tradeType === TRADE_TYPE.OFFER
+            ? chatToOfferedUserModalOpen
+            : handleDirectChatInitiation
         } // 오퍼 게시물 일때 채팅하기 버튼 클릭 시 모달 오픈, 1:1 게시물 일때 채팅하기 버튼 클릭 시 바로 채팅방으로 이동
       />
+      {isDeletePostLoading && <Spinner />}
       {isOpen && (
         <BottomSheet height={'200px'} onClick={close}>
-          {/* Todo: 수정, 삭제 기능 추가 해야함 */}
           <A.CorrectionButton
-            onClick={() =>
-              navigate(`edit/select-element`, { state: ProductInfoData })
-            }
+            onClick={() => navigate(`edit/select-element`, { state: post })}
           >
             게시물 수정
           </A.CorrectionButton>
@@ -193,7 +192,6 @@ function Articles() {
         content="게시물을 삭제하시겠습니까?"
         confirmedContent="게시물이 삭제되었습니다."
         onConfirmAction={handleDeletePost}
-        onCompletedAction={handleDeleteComplete}
         closeAction={deleteModalClose}
       />
     </>

--- a/src/components/Articles/PostActionButtons.tsx/PostActionButtons.tsx
+++ b/src/components/Articles/PostActionButtons.tsx/PostActionButtons.tsx
@@ -7,12 +7,14 @@ import ActionButton from '@/components/common/Buttons/ActionButton';
 interface IPostActionsProps {
   isOfferPost: boolean;
   isOwner: boolean;
+  isEnded: boolean;
   onChatButtonClick: () => void;
 }
 
 function PostActions({
   isOfferPost,
   isOwner,
+  isEnded,
   onChatButtonClick,
 }: IPostActionsProps) {
   const navigate = useNavigate();
@@ -25,18 +27,25 @@ function PostActions({
     <P.Container>
       <LikeButton isLiked={false} />
       <P.ButtonsContainer $isOfferPost={isOfferPost}>
-        {isOfferPost && (
+        {isEnded && (
+          <ActionButton onClick={() => {}} disabled={isEnded}>
+            거래가 마감되었습니다.
+          </ActionButton>
+        )}
+        {!isEnded && isOfferPost && (
           <ActionButton onClick={handleCommentButtonClick} disabled={isOwner}>
             댓글쓰기
           </ActionButton>
         )}
-        <BlueButton
-          className={!isOfferPost && 'only-chat'}
-          disabled={(!isOfferPost && isOwner) || (isOfferPost && !isOwner)}
-          onClick={onChatButtonClick}
-        >
-          채팅하기
-        </BlueButton>
+        {!isEnded && (
+          <BlueButton
+            className={!isOfferPost && 'only-chat'}
+            disabled={(!isOfferPost && isOwner) || (isOfferPost && !isOwner)}
+            onClick={onChatButtonClick}
+          >
+            채팅하기
+          </BlueButton>
+        )}
       </P.ButtonsContainer>
     </P.Container>
   );

--- a/src/components/Articles/ProductImagesContainer/ProductImagesContainer.tsx
+++ b/src/components/Articles/ProductImagesContainer/ProductImagesContainer.tsx
@@ -1,22 +1,23 @@
+import { IImage } from '@/types/PostTypes';
 import styled from 'styled-components';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 export const ProductImage = styled.img`
   width: 100%;
   height: 300px;
-  object-fit: cover;
+  object-fit: contain;
 `;
 
 interface IProductImagesContainerProps {
-  images: string[];
+  images: IImage[];
 }
 
 function ProductImagesContainer({ images }: IProductImagesContainerProps) {
   return (
-    <Swiper spaceBetween={0} slidesPerView={1}>
+    <Swiper spaceBetween={5} slidesPerView={1} style={{ marginTop: '12px' }}>
       {images.map((image, index) => (
         <SwiperSlide key={index}>
-          <ProductImage src={image} alt={`제품 이미지 ${index + 1}`} />
+          <ProductImage src={image.imageUrl} alt={`제품 이미지 ${index + 1}`} />
         </SwiperSlide>
       ))}
     </Swiper>

--- a/src/components/Articles/ProductInfo/ProductInfo.tsx
+++ b/src/components/Articles/ProductInfo/ProductInfo.tsx
@@ -1,3 +1,4 @@
+import { TRADE_TIME, TradeTimeType } from '@/types/PostTypes';
 import * as P from './ProductInfoStyles';
 import Title from '@components/common/BigTitle';
 
@@ -7,8 +8,8 @@ interface IProductInfoProps {
   uploadTime: string;
   deadLine: string;
   desiredCategory: string;
-  tradeTime: string;
-  price: string;
+  tradeTime: TradeTimeType;
+  price: number[];
   description: string;
 }
 
@@ -22,7 +23,23 @@ function ProductInfo({
   price,
   description,
 }: IProductInfoProps) {
-  // Todo: Props 형식 처리 해야됨. Ex) 날짜, 가격
+  let tradeTimeText = '';
+
+  switch (tradeTime) {
+    case TRADE_TIME.EARLY_MORNING:
+      tradeTimeText = '이른 아침(06시 ~ 09시)';
+      break;
+    case TRADE_TIME.MORNING:
+      tradeTimeText = '오전(09시 ~ 12시)';
+      break;
+    case TRADE_TIME.AFTERNOON:
+      tradeTimeText = '오후(12시 ~ 18시)';
+      break;
+    case TRADE_TIME.EVENING:
+      tradeTimeText = '저녁(18시 ~ 00시)';
+      break;
+  }
+
   return (
     <P.Container>
       <P.TitleContainer>
@@ -43,11 +60,13 @@ function ProductInfo({
         </div>
         <div>
           <P.InfoTitle>거래 가능 시간</P.InfoTitle>
-          <P.InfoDate>{tradeTime}</P.InfoDate>
+          <P.InfoDate>{tradeTimeText}</P.InfoDate>
         </div>
         <div>
           <P.InfoTitle>가격 제안</P.InfoTitle>
-          <div className="price">{price} 원</div>
+          <div className="price">
+            {price.map((item) => item.toLocaleString('kr-KR') + '원').join('~')}
+          </div>
         </div>
       </P.InfoContainer>
       <P.Description>{description}</P.Description>

--- a/src/store/api/apiSlice.ts
+++ b/src/store/api/apiSlice.ts
@@ -69,6 +69,6 @@ const baseQueryWithIntercept: BaseQueryFn<
 export const apiSlice = createApi({
   reducerPath: 'api',
   baseQuery: baseQueryWithIntercept,
-  tagTypes: ['User'],
+  tagTypes: ['User', 'Post'],
   endpoints: () => ({}),
 });

--- a/src/store/api/postApiSlice.ts
+++ b/src/store/api/postApiSlice.ts
@@ -1,0 +1,12 @@
+import { IPost } from '@/types/PostTypes';
+import { apiSlice } from './apiSlice';
+
+export const postApiSlice = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getPostDetail: builder.query<IPost, string>({
+      query: (id) => `/v1/posts/${id}`,
+    }),
+  }),
+});
+
+export const { useGetPostDetailQuery } = postApiSlice;

--- a/src/store/api/postApiSlice.ts
+++ b/src/store/api/postApiSlice.ts
@@ -5,8 +5,16 @@ export const postApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getPostDetail: builder.query<IPost, string>({
       query: (id) => `/v1/posts/${id}`,
+      providesTags: (result, error, id) => [{ type: 'Post', id }],
+    }),
+    deletePost: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `/v1/posts/${id}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (result, error, id) => [{ type: 'Post', id }],
     }),
   }),
 });
 
-export const { useGetPostDetailQuery } = postApiSlice;
+export const { useGetPostDetailQuery, useDeletePostMutation } = postApiSlice;

--- a/src/types/PostTypes.ts
+++ b/src/types/PostTypes.ts
@@ -1,0 +1,46 @@
+import { IUser } from './UserTypes';
+
+export const POST_TYPE = {
+  GOODS: 'GOODS',
+  TALENT: 'TALENT',
+} as const;
+
+export const TRADE_TYPE = {
+  SINGLE_TRADE: 'SINGLE_TRADE',
+  OFFER: 'OFFER ',
+} as const;
+
+type PostType = (typeof POST_TYPE)[keyof typeof POST_TYPE];
+type TradeType = (typeof TRADE_TYPE)[keyof typeof TRADE_TYPE];
+
+export interface IImage {
+  id: number;
+  imageUrl: string;
+  createdAt: string;
+  modifiedAt: string;
+}
+
+interface IPostAddress {
+  region1: string;
+  region2: string;
+  region3: string;
+  latitude: number;
+  longitude: number;
+}
+
+export interface IPost {
+  id: number;
+  writer: IUser;
+  title: string;
+  content: string;
+  images: IImage[];
+  postType: PostType;
+  tradeType: TradeType;
+  provisionCategory: string;
+  wishCategory: string;
+  suggestedPrice: number[];
+  address: IPostAddress;
+  closeAt: string;
+  createdAt: string;
+  modifiedAt: string;
+}

--- a/src/types/PostTypes.ts
+++ b/src/types/PostTypes.ts
@@ -7,11 +7,19 @@ export const POST_TYPE = {
 
 export const TRADE_TYPE = {
   SINGLE_TRADE: 'SINGLE_TRADE',
-  OFFER: 'OFFER ',
+  OFFER: 'OFFER',
 } as const;
+
+export const TRADE_TIME = {
+  EARLY_MORNING: 'EARLY_MORNING',
+  MORNING: 'MORNING',
+  AFTERNOON: 'AFTERNOON',
+  EVENING: 'EVENING',
+};
 
 type PostType = (typeof POST_TYPE)[keyof typeof POST_TYPE];
 type TradeType = (typeof TRADE_TYPE)[keyof typeof TRADE_TYPE];
+export type TradeTimeType = (typeof TRADE_TIME)[keyof typeof TRADE_TIME];
 
 export interface IImage {
   id: number;
@@ -43,4 +51,5 @@ export interface IPost {
   closeAt: string;
   createdAt: string;
   modifiedAt: string;
+  tradeTime: TradeTimeType;
 }


### PR DESCRIPTION
## 작업 목록
- 게시글 상세 조회 API 연결
- 거래 마감일 이후 거래 마감 관련 UI 표시
- 1:1 & 오퍼 구분
- writer id와 user id로 작성자 판별

## Todo
- 게시글 목록 조회가 구현이 안되있기 때문에 구현이 되면 id로 받아서 보여줘야 함.
- 오퍼 관련 기능 구현시 오퍼 목록 조회 기능 필요